### PR TITLE
Replace mkdir with makedir for nested directory creation

### DIFF
--- a/DailyProgrammer.py
+++ b/DailyProgrammer.py
@@ -84,7 +84,7 @@ def startChallenge(window, title, url):
     filePath = os.path.join(folderPath, fileName)
 
     if not os.path.exists(folderPath):
-        os.mkdir(folderPath)
+        os.makedirs(folderPath)
         with open(filePath, "w") as f:
             f.write(contents)
 


### PR DESCRIPTION
Currently, nothing at all happens if the directory in challengePaths, or any parent directory of that directory doesn't exist.  By using makedirs, the directory is created instead.  The downside is, of course, that a typo can potentially create a deep unwanted folder structure.

An alternative could be some sort of user feedback, telling them that the expected directory doesn't exist rather than them having to look in console.
