### PR TITLE
Added version numbering to the challenges.

### DIFF
--- a/DailyProgrammer.py
+++ b/DailyProgrammer.py
@@ -38,6 +38,9 @@ initialCursor = (6, 9)
 # valid characters for path
 validChars = '-_.()[]! abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
 
+# Needs updating when the data retrieved for challenges changes.
+challengeVersion = 2
+
 
 def checkIfConfigReady(window):
     if challengesPath == r"enter your path here!":
@@ -79,11 +82,16 @@ def updateChallenges(challenges, limit):
 def getAllChallenges():
     config = sublime.load_settings('DailyProgrammer.sublime-settings')
     challenges = config.get("challenges", [])
+    savedVersion = config.get("challenge_version", 0)
+
+    if challengeVersion != savedVersion:
+        challenges = [] # Force refresh to ensure all information retrieved
 
     updatedChallenges = updateChallenges(challenges, 100 if challenges == [] else 10)
 
     if challenges != updatedChallenges:
         config.set("challenges", updatedChallenges)
+        config.set("challenge_version", challengeVersion)
         sublime.save_settings('DailyProgrammer.sublime-settings')
 
     return updatedChallenges


### PR DESCRIPTION
Currently, with the challenges cached in the settings file, nothing happens when you attempt to start a new challenge as the desc field is missing, throwing an exception for the missing positional argument.

This commit fixes the failure to run caused by having a cached version of the challenges without the desc field, and should be forwards-compatible for any further changes to the format of the stored challenges by changing the version number.

An alternative I considered is passing the dictionary into startChallenge intact as the **kwArgs parameter, leaving an empty string for desc by default.  This might in fact be better for future extensibility (and I personally dislike loads of positional arguments ^^).
